### PR TITLE
fix: 선택 창에 정수가 아닌 수 입력시 무한루프 생기는 것 해결

### DIFF
--- a/src/main/java/com/example/kiosk_1/Kiosk.java
+++ b/src/main/java/com/example/kiosk_1/Kiosk.java
@@ -48,14 +48,22 @@ public class Kiosk {
                 if (sc.hasNextInt()) {
                     select = sc.nextInt();
                     sc.nextLine();  // 버퍼 비우기
-                    // 입력값 유효성검사: 사용자 입력값이 적절한 경우
-                    if (select >= 0 && select <= totalMenus.size()) {
-                        selectCategory=select;
-                        break;
-                    }
+                }
+                else {
+                    sc.nextLine();
+                    System.out.println("올바른 카테고리 번호를 입력하세요");
+                    continue;
+                }
+
+                // 입력값 유효성검사: 사용자 입력값이 적절한 경우
+                if (select >= 0 && select <= totalMenus.size()) {
+                    selectCategory = select;
+                    break;
                 }
                 System.out.println("올바른 카테고리 번호를 입력하세요");
             }
+            // 사용자가 입력한 번호에 따라 다른 로직 구현
+            // 0 입력시 프로그램 종료
             if (select == 0) {
                 System.out.println("키오스크를 종료합니다.");
                 System.exit(0);
@@ -70,6 +78,11 @@ public class Kiosk {
                 if (sc.hasNextInt()) {
                     select = sc.nextInt();
                     sc.nextLine();  // 버퍼 비우기
+                }
+                else {
+                    sc.nextLine();
+                    System.out.println("올바른 메뉴 번호를 입력하세요");
+                    continue;
                 }
                 // 입력값 유효성검사: 사용자 입력값이 적절한 경우
                 if (select >= 0 && select <= totalMenus.get(selectCategory - 1).getCategoryItems().size()) {


### PR DESCRIPTION
resolves: #16 

## 문제상황
선택 창에 입력된 값의 종류에 따라 무한루프가 발생 
- ✅ 자연수와 0 : 유효성 검사 올바르게 작동
- ✅ 음의 정수 : 유효성 검사 올바르게 작동
- ❌ 소수 : 무한루프
- ❌ 문자 : 무한루프
- ❌문자열 : 무한루프

|![Image](https://github.com/user-attachments/assets/bfaeb5fb-ce62-4c58-9949-b278d12a3401)|![Image](https://github.com/user-attachments/assets/ea69614c-5699-483b-8e08-77c82b53420f)|
| --- | --- |

## 예상원인
아래 코드에서 sc.hasNextInt() 가 false인 상황에서의 처리문이 없음
그러면, 버퍼에 값이 계속 남아있으므로
else 로 버퍼를 비워주는 코드가 필요함
```java
while (true) {
                System.out.print("카테고리 번호 입력 >> ");
                if (sc.hasNextInt()) {
                    select = sc.nextInt();
                    sc.nextLine();  // 버퍼 비우기
                    // 입력값 유효성검사: 사용자 입력값이 적절한 경우
                    if (select >= 0 && select <= totalMenus.size()) {
                        selectCategory=select;
                        break;
                    }
                }
                System.out.println("올바른 카테고리 번호를 입력하세요");
            }
```

## 해결결과
else 로 버퍼를 비워주는 코드 작성하여 해결함
```java
while (true) {
                System.out.print("카테고리 번호 입력 >> ");
                if (sc.hasNextInt()) {
                    select = sc.nextInt();
                    sc.nextLine();  // 버퍼 비우기
                }
                else {
                    sc.nextLine();
                    System.out.println("올바른 카테고리 번호를 입력하세요");
                    continue;
                }

                // 입력값 유효성검사: 사용자 입력값이 적절한 경우
                if (select >= 0 && select <= totalMenus.size()) {
                    selectCategory = select;
                    break;
                }
                System.out.println("올바른 카테고리 번호를 입력하세요");
            }
```

![Image](https://github.com/user-attachments/assets/8c1735ed-bcc4-4467-94de-5a4c880ccd9d)